### PR TITLE
Synchronize executeSubsequently

### DIFF
--- a/src/main/java/net/haesleinhuepf/clij2/CLIJ2.java
+++ b/src/main/java/net/haesleinhuepf/clij2/CLIJ2.java
@@ -208,7 +208,7 @@ public class CLIJ2 implements CLIJ2Ops {
         return executeSubsequently(anchorClass, pProgramFilename, pKernelname, dimensions, globalsizes, null, parameters, constants, kernel);
     }
 
-    public ClearCLKernel executeSubsequently(Class anchorClass, String pProgramFilename, String pKernelname, long[] dimensions, long[] globalsizes, long[] localSizes, HashMap<String, Object> parameters, HashMap<String, Object> constants, ClearCLKernel kernel) {
+    public synchronized ClearCLKernel executeSubsequently(Class anchorClass, String pProgramFilename, String pKernelname, long[] dimensions, long[] globalsizes, long[] localSizes, HashMap<String, Object> parameters, HashMap<String, Object> constants, ClearCLKernel kernel) {
 
         final ClearCLKernel[] result = {kernel};
 


### PR DESCRIPTION
This is required to make CLIJ2 work, when used in a multithreaded application. 