### PR TITLE
replaced CONVERT_sum_PIXEL_TYPE with CONVERT_dst_PIXEL_TYPE 

### DIFF
--- a/src/main/java/net/haesleinhuepf/clij2/plugins/variance_projection_x.cl
+++ b/src/main/java/net/haesleinhuepf/clij2/plugins/variance_projection_x.cl
@@ -13,5 +13,5 @@ __kernel void squared_sum_project(
     float value = READ_src_IMAGE(src,sampler,POS_src_INSTANCE(x,y,z,0)).x;
     sum = sum + pow(value - mean_intensity, 2);
   }
-  WRITE_dst_IMAGE(dst,POS_dst_INSTANCE(x,y,0,0), CONVERT_sum_PIXEL_TYPE(sum));
+  WRITE_dst_IMAGE(dst,POS_dst_INSTANCE(x,y,0,0), CONVERT_dst_PIXEL_TYPE(sum));
 }


### PR DESCRIPTION
replaced CONVERT_sum_PIXEL_TYPE with CONVERT_dst_PIXEL_TYPE  in variance_projection_x.cl
to fix: https://github.com/clij/clij2/issues/60 as per: https://github.com/clij/clij2/issues/60#issuecomment-1203182294

